### PR TITLE
Make all tests visible

### DIFF
--- a/ABasicCalculator/BranchingIfElse/Task/task-info.yaml
+++ b/ABasicCalculator/BranchingIfElse/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/Factorial/Task/task-info.yaml
+++ b/ABasicCalculator/Factorial/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/Integers/Task/task-info.yaml
+++ b/ABasicCalculator/Integers/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/Introduction/ABasicCalculatorIntroduction/task-info.yaml
+++ b/ABasicCalculator/Introduction/ABasicCalculatorIntroduction/task-info.yaml
@@ -10,5 +10,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/LoopsFor/Task/task-info.yaml
+++ b/ABasicCalculator/LoopsFor/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/LoopsWhile/Task/task-info.yaml
+++ b/ABasicCalculator/LoopsWhile/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/Panics/Task/task-info.yaml
+++ b/ABasicCalculator/Panics/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/SaturatingArithmetic/Task/task-info.yaml
+++ b/ABasicCalculator/SaturatingArithmetic/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/ABasicCalculator/Variables/Task/task-info.yaml
+++ b/ABasicCalculator/Variables/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Futures/AsynchronousFunctions/Task/task-info.yaml
+++ b/Futures/AsynchronousFunctions/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Futures/BlockingTheRuntime/Task/task-info.yaml
+++ b/Futures/BlockingTheRuntime/Task/task-info.yaml
@@ -14,5 +14,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Futures/Introduction/Futures - Introduction/task-info.yaml
+++ b/Futures/Introduction/Futures - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Futures/Outro/Task/task-info.yaml
+++ b/Futures/Outro/Task/task-info.yaml
@@ -27,7 +27,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/main.rs
     visible: true

--- a/Futures/Runtime/Task/task-info.yaml
+++ b/Futures/Runtime/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Futures/SpawningTasks/Task/task-info.yaml
+++ b/Futures/SpawningTasks/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Introduction/GettingStarted/HelloWorld/task-info.yaml
+++ b/Introduction/GettingStarted/HelloWorld/task-info.yaml
@@ -10,7 +10,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
   - name: images/run_dark.svg
     visible: false
   - name: images/run.svg

--- a/Threads/BoundedChannels/Task/task-info.yaml
+++ b/Threads/BoundedChannels/Task/task-info.yaml
@@ -42,7 +42,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/store.rs
     visible: true

--- a/Threads/Client/Task/task-info.yaml
+++ b/Threads/Client/Task/task-info.yaml
@@ -15,7 +15,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/store.rs
     visible: true

--- a/Threads/InteriorMutability/Task/task-info.yaml
+++ b/Threads/InteriorMutability/Task/task-info.yaml
@@ -15,5 +15,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Threads/Introduction/Threads - Introduction/task-info.yaml
+++ b/Threads/Introduction/Threads - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Threads/LeakingMemory/Task/task-info.yaml
+++ b/Threads/LeakingMemory/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Threads/MutexSendAndArc/Task/task-info.yaml
+++ b/Threads/MutexSendAndArc/Task/task-info.yaml
@@ -5,7 +5,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/store.rs
     visible: true

--- a/Threads/Patching/Task/task-info.yaml
+++ b/Threads/Patching/Task/task-info.yaml
@@ -12,7 +12,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/store.rs
     visible: true

--- a/Threads/RwLock/Task/task-info.yaml
+++ b/Threads/RwLock/Task/task-info.yaml
@@ -14,7 +14,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/store.rs
     visible: true

--- a/Threads/ScopedThreads/Task/task-info.yaml
+++ b/Threads/ScopedThreads/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Threads/StaticLifetime/Task/task-info.yaml
+++ b/Threads/StaticLifetime/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Threads/SyncTrait/Task/task-info.yaml
+++ b/Threads/SyncTrait/Task/task-info.yaml
@@ -9,4 +9,4 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true

--- a/Threads/Threads/Task/task-info.yaml
+++ b/Threads/Threads/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/BTreeMap/Task/task-info.yaml
+++ b/TicketManagement/BTreeMap/Task/task-info.yaml
@@ -24,5 +24,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Combinators/Task/task-info.yaml
+++ b/TicketManagement/Combinators/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/HashMap/Task/task-info.yaml
+++ b/TicketManagement/HashMap/Task/task-info.yaml
@@ -21,5 +21,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/ImplTrait/Task/task-info.yaml
+++ b/TicketManagement/ImplTrait/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/IndexMutTrait/Task/task-info.yaml
+++ b/TicketManagement/IndexMutTrait/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/IndexTrait/Task/task-info.yaml
+++ b/TicketManagement/IndexTrait/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Introduction/Ticket Management - Introduction/task-info.yaml
+++ b/TicketManagement/Introduction/Ticket Management - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Iter/Task/task-info.yaml
+++ b/TicketManagement/Iter/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Iterators/Task/task-info.yaml
+++ b/TicketManagement/Iterators/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Lifetimes/Task/task-info.yaml
+++ b/TicketManagement/Lifetimes/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/MutableSlices/Task/task-info.yaml
+++ b/TicketManagement/MutableSlices/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Slices/Task/task-info.yaml
+++ b/TicketManagement/Slices/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/TwoStates/Task/task-info.yaml
+++ b/TicketManagement/TwoStates/Task/task-info.yaml
@@ -22,5 +22,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketManagement/Vectors/Task/task-info.yaml
+++ b/TicketManagement/Vectors/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Destructors/Task/task-info.yaml
+++ b/TicketV1/Destructors/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Encapsulation/Task/task-info.yaml
+++ b/TicketV1/Encapsulation/Task/task-info.yaml
@@ -15,5 +15,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Introduction/Ticket v1 - Introduction/task-info.yaml
+++ b/TicketV1/Introduction/Ticket v1 - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Ownership/Task/task-info.yaml
+++ b/TicketV1/Ownership/Task/task-info.yaml
@@ -27,5 +27,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Setters/Task/task-info.yaml
+++ b/TicketV1/Setters/Task/task-info.yaml
@@ -43,5 +43,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV1/Validation/Task/task-info.yaml
+++ b/TicketV1/Validation/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/BranchingIfLetAndLetElse/Task/task-info.yaml
+++ b/TicketV2/BranchingIfLetAndLetElse/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/BranchingMatch/Task/task-info.yaml
+++ b/TicketV2/BranchingMatch/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/Enums/Task/task-info.yaml
+++ b/TicketV2/Enums/Task/task-info.yaml
@@ -18,5 +18,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/ErrorEnums/Task/task-info.yaml
+++ b/TicketV2/ErrorEnums/Task/task-info.yaml
@@ -35,5 +35,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/ErrorSource/Task/task-info.yaml
+++ b/TicketV2/ErrorSource/Task/task-info.yaml
@@ -12,7 +12,7 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false
   - name: src/status.rs
     visible: true

--- a/TicketV2/ErrorTrait/Task/task-info.yaml
+++ b/TicketV2/ErrorTrait/Task/task-info.yaml
@@ -15,5 +15,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/Fallibility/Task/task-info.yaml
+++ b/TicketV2/Fallibility/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/Introduction/Ticket v2 - Introduction/task-info.yaml
+++ b/TicketV2/Introduction/Ticket v2 - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/Nullability/Task/task-info.yaml
+++ b/TicketV2/Nullability/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/TryFromTrait/Task/task-info.yaml
+++ b/TicketV2/TryFromTrait/Task/task-info.yaml
@@ -15,5 +15,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/Unwrap/Task/task-info.yaml
+++ b/TicketV2/Unwrap/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/VariantsWithData/Task/task-info.yaml
+++ b/TicketV2/VariantsWithData/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/TicketV2/thiserror/Task/task-info.yaml
+++ b/TicketV2/thiserror/Task/task-info.yaml
@@ -25,5 +25,5 @@ files:
         length: 20
         placeholder_text: "# TODO"
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/AssociatedVsGenericTypes/Task/task-info.yaml
+++ b/Traits/AssociatedVsGenericTypes/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/DerefTrait/Task/task-info.yaml
+++ b/Traits/DerefTrait/Task/task-info.yaml
@@ -12,5 +12,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/DeriveMacros/Task/task-info.yaml
+++ b/Traits/DeriveMacros/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/Introduction/Traits - Introduction/task-info.yaml
+++ b/Traits/Introduction/Traits - Introduction/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/OperatorOverloading/Task/task-info.yaml
+++ b/Traits/OperatorOverloading/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/OrphanRule/Task/task-info.yaml
+++ b/Traits/OrphanRule/Task/task-info.yaml
@@ -10,5 +10,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/StringSlices/Task/task-info.yaml
+++ b/Traits/StringSlices/Task/task-info.yaml
@@ -15,5 +15,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false

--- a/Traits/Trait/Task/task-info.yaml
+++ b/Traits/Trait/Task/task-info.yaml
@@ -9,5 +9,5 @@ files:
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs
-    visible: false
+    visible: true
     propagatable: false


### PR DESCRIPTION
Made all tests visible to the students.

# Reasons for the change

+ In the original course the test are open
+ A lot of tasks actually require you to read the tests to complete them. You are expected to get the expected enum variants, error messages and function signatures from the tests.
+ Open tests make it easier to feed them into AI to get hints and clarifications

# Change methodology 

The change was made with the script below to ensure that I don't miss any files.

The script assumes that there is `- name: {file}` entry for every `tests.rs` and `integration.rs` and that there are no other files in tests worth seeing. I tested this assumption with other scripts. I ran scripts to see what can possibly be in the tests folder: it was either `tests.rs`, `integration.rs` or `input.txt` + `output.txt` (both empty). I made only the `tests.rs` and `integration.rs` visible.

```python
#!/usr/bin/env python3
"""
Script to update task-info.yaml files:
- Replace "visible: false" with "visible: true" for tests/tests.rs and tests/integration.rs entries
- Report files where "visible" property is missing for test entries
"""

import os
import re
from pathlib import Path

PROJECT_PATH = "/Users/daria/Documents/100-exercises-to-learn-rust"

def find_task_info_files():
    """Find all task-info.yaml files in the project."""
    result = []
    for root, dirs, files in os.walk(PROJECT_PATH):
        if "task-info.yaml" in files:
            result.append(os.path.join(root, "task-info.yaml"))
    return result

def process_task_info(filepath):
    """
    Process a task-info.yaml file.
    Returns tuple: (modified: bool, missing_visible: list of test files without visible property)
    """
    with open(filepath, "r") as f:
        content = f.read()
    
    original_content = content
    missing_visible = []
    
    # Pattern to match test file entries (tests/tests.rs or tests/integration.rs)
    # We need to find the entry and check/modify its visible property
    
    test_files = ["tests/tests.rs", "tests/integration.rs"]
    
    for test_file in test_files:
        # Check if this test file is referenced in the yaml
        if f"- name: {test_file}" not in content:
            continue
        
        # Pattern to match the entry block for this test file
        # Looking for "- name: tests/tests.rs" followed by properties until the next "- name:" or end
        pattern = rf"(- name: {re.escape(test_file)}\n)((?:[ \t]+\w+:.*\n)*)"
        match = re.search(pattern, content)
        
        if match:
            entry_start = match.group(1)
            entry_props = match.group(2)
            
            if "visible:" not in entry_props:
                # No visible property found
                missing_visible.append(test_file)
            elif "visible: false" in entry_props:
                # Replace visible: false with visible: true
                new_props = entry_props.replace("visible: false", "visible: true")
                content = content.replace(entry_start + entry_props, entry_start + new_props)
            # If visible: true already exists, no action needed
    
    modified = content != original_content
    
    if modified:
        with open(filepath, "w") as f:
            f.write(content)
    
    return modified, missing_visible

def main():
    task_info_files = find_task_info_files()
    
    print("=" * 70)
    print("Processing task-info.yaml files...")
    print("=" * 70)
    
    modified_count = 0
    files_with_missing_visible = []
    
    for filepath in task_info_files:
        modified, missing_visible = process_task_info(filepath)
        
        relative_path = os.path.relpath(filepath, PROJECT_PATH)
        parent_of_parent = Path(filepath).parent.parent.name
        
        if modified:
            modified_count += 1
            print(f"  MODIFIED: {relative_path}")
        
        if missing_visible:
            files_with_missing_visible.append((parent_of_parent, relative_path, missing_visible))
    
    print("\n" + "=" * 70)
    print(f"Summary: Modified {modified_count} file(s)")
    print("=" * 70)
    
    if files_with_missing_visible:
        print("\nFiles where 'visible' property is MISSING for test entries:")
        print("-" * 70)
        for parent_name, filepath, missing in files_with_missing_visible:
            print(f"  {parent_name}: {filepath}")
            for test_file in missing:
                print(f"      - {test_file} has no 'visible' property")
    else:
        print("\nAll test file entries have the 'visible' property.")

if __name__ == "__main__":
    main()
```

# Further info

Making the `tests.rs` and `integration.rs` files open is not the end of the story. I recall at least one exercise where I'd like to make `Cargo.toml` visible as well. But I will do it in a separate pull-request.