### PR TITLE
Fix placeholder positions

### DIFF
--- a/ABasicCalculator/Panics/Task/task-info.yaml
+++ b/ABasicCalculator/Panics/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 342
+      - offset: 338
         length: 99
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/Threads/AckPattern/Task/task-info.yaml
+++ b/Threads/AckPattern/Task/task-info.yaml
@@ -10,17 +10,17 @@ files:
         length: 62
         placeholder_text: /* TODO */
       - offset: 795
-        length: 28
-        placeholder_text: /* TODO */
-      - offset: 863
-        length: 83
-        placeholder_text: /* TODO */
-      - offset: 1010
         length: 39
         placeholder_text: /* TODO */
-      - offset: 1089
-        length: 90
+      - offset: 871
+        length: 83
+        placeholder_text: todo!()
+      - offset: 1015
+        length: 36
         placeholder_text: /* TODO */
+      - offset: 1088
+        length: 90
+        placeholder_text: todo!()
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs

--- a/Threads/BoundedChannels/Task/task-info.yaml
+++ b/Threads/BoundedChannels/Task/task-info.yaml
@@ -5,40 +5,40 @@ files:
     placeholders:
       - offset: 280
         length: 19
-        placeholder_text: /* TODO */
-      - offset: 377
+        placeholder_text: todo!()
+      - offset: 394
         length: 15
-        placeholder_text: /* TODO */
-      - offset: 404
+        placeholder_text: todo!()
+      - offset: 421
         length: 315
-        placeholder_text: /* TODO */
-      - offset: 789
+        placeholder_text: todo!()
+      - offset: 806
         length: 15
-        placeholder_text: /* TODO */
-      - offset: 816
+        placeholder_text: todo!()
+      - offset: 833
         length: 309
-        placeholder_text: /* TODO */
-      - offset: 1135
+        placeholder_text: todo!()
+      - offset: 1152
         length: 98
         placeholder_text: /* TODO */
-      - offset: 1293
+      - offset: 1310
         length: 65
         placeholder_text: /* TODO */
-      - offset: 1413
+      - offset: 1430
         length: 28
         placeholder_text: /* TODO */
-      - offset: 1527
+      - offset: 1544
         length: 20
-        placeholder_text: /* TODO */
-      - offset: 1614
+        placeholder_text: todo!()
+      - offset: 1631
         length: 26
-        placeholder_text: /* TODO */
-      - offset: 1961
+        placeholder_text: todo!()
+      - offset: 1969
         length: 34
-        placeholder_text: /* TODO */
-      - offset: 2183
+        placeholder_text: todo!()
+      - offset: 2182
         length: 47
-        placeholder_text: /* TODO */
+        placeholder_text: todo!()
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs

--- a/Threads/Client/Task/task-info.yaml
+++ b/Threads/Client/Task/task-info.yaml
@@ -5,13 +5,13 @@ files:
     placeholders:
       - offset: 430
         length: 280
-        placeholder_text: /* TODO */
+        placeholder_text: todo!()
       - offset: 782
         length: 274
-        placeholder_text: /* TODO */
+        placeholder_text: todo!()
       - offset: 1216
         length: 28
-        placeholder_text: /* TODO */
+        placeholder_text: todo!()
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs

--- a/Threads/Patching/Task/task-info.yaml
+++ b/Threads/Patching/Task/task-info.yaml
@@ -6,7 +6,7 @@ files:
       - offset: 1223
         length: 312
         placeholder_text: /* TODO */
-      - offset: 2841
+      - offset: 2840
         length: 513
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/TicketManagement/Arrays/Task/task-info.yaml
+++ b/TicketManagement/Arrays/Task/task-info.yaml
@@ -6,17 +6,17 @@ files:
       - offset: 134
         length: 30
         placeholder_text: /* TODO */
-      - offset: 340
-        length: 64
-        placeholder_text: /* TODO */
-      - offset: 485
+      - offset: 342
         length: 65
         placeholder_text: /* TODO */
-      - offset: 638
+      - offset: 488
+        length: 65
+        placeholder_text: /* TODO */
+      - offset: 641
         length: 86
         placeholder_text: /* TODO */
-      - offset: 734
-        length: 283
+      - offset: 737
+        length: 284
         placeholder_text: "/* TODO: Create weekday2index method which converts a Weekday\
       \ enum variant into its corresponding zero-based index. */"
   - name: Cargo.toml

--- a/TicketManagement/HashMap/Task/task-info.yaml
+++ b/TicketManagement/HashMap/Task/task-info.yaml
@@ -7,7 +7,7 @@ files:
         length: 10
         placeholder_text: /* TODO */
       - offset: 909
-        length: 15
+        length: 14
         placeholder_text: todo!()
       - offset: 1279
         length: 32

--- a/TicketManagement/ImplTrait/Task/task-info.yaml
+++ b/TicketManagement/ImplTrait/Task/task-info.yaml
@@ -3,8 +3,8 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 736
-        length: 171
+      - offset: 732
+        length: 173
         placeholder_text: /* TODO */
   - name: Cargo.toml
     visible: false

--- a/TicketManagement/Iter/Task/task-info.yaml
+++ b/TicketManagement/Iter/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 1091
+      - offset: 1092
         length: 82
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/TicketManagement/Iterators/Task/task-info.yaml
+++ b/TicketManagement/Iterators/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 1321
+      - offset: 1320
         length: 196
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/TicketManagement/TwoStates/Task/task-info.yaml
+++ b/TicketManagement/TwoStates/Task/task-info.yaml
@@ -4,7 +4,7 @@ files:
     visible: true
     placeholders:
       - offset: 486
-        length: 16
+        length: 14
         placeholder_text: /* TODO */
       - offset: 1078
         length: 11

--- a/TicketV1/Encapsulation/Task/task-info.yaml
+++ b/TicketV1/Encapsulation/Task/task-info.yaml
@@ -3,14 +3,8 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 1235
-        length: 63
-        placeholder_text: /* TODO */
-      - offset: 1308
-        length: 75
-        placeholder_text: /* TODO */
-      - offset: 1393
-        length: 65
+      - offset: 1227
+        length: 223
         placeholder_text: /* TODO */
   - name: Cargo.toml
     visible: false

--- a/TicketV1/Ownership/Task/task-info.yaml
+++ b/TicketV1/Ownership/Task/task-info.yaml
@@ -4,21 +4,21 @@ files:
     visible: true
     placeholders:
       - offset: 1144
-        length: 58
+        length: 59
         placeholder_text: |-
           // TODO:
               pub fn title(self) -> String {
                   self.title
               }
       - offset: 1208
-        length: 70
+        length: 71
         placeholder_text: |-
           // TODO:
               pub fn description(self) -> String {
                   self.description
               }
       - offset: 1284
-        length: 60
+        length: 61
         placeholder_text: |-
           // TODO:
               pub fn status(self) -> String {

--- a/TicketV1/Setters/Task/task-info.yaml
+++ b/TicketV1/Setters/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 477
+      - offset: 478
         length: 101
         placeholder_text: |-
           // TODO:
@@ -22,22 +22,22 @@ files:
                   if status != "To-Do" && status != "In Progress" && status != "Done" {
                       panic!("Only `To-Do`, `In Progress`, and `Done` statuses are allowed");
                   }
-      - offset: 888
+      - offset: 889
         length: 110
         placeholder_text: "/* TODO: set_title */"
-      - offset: 1004
+      - offset: 1005
         length: 146
         placeholder_text: "/* TODO: set_description */"
-      - offset: 1156
+      - offset: 1157
         length: 116
         placeholder_text: "/* TODO: set_status */"
-      - offset: 1316
+      - offset: 1317
         length: 156
         placeholder_text: /* TODO */
-      - offset: 1528
+      - offset: 1529
         length: 182
         placeholder_text: /* TODO */
-      - offset: 1756
+      - offset: 1757
         length: 155
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/TicketV1/Validation/Task/task-info.yaml
+++ b/TicketV1/Validation/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 1137
+      - offset: 1128
         length: 561
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/TicketV1/Visibility/Task/task-info.yaml
+++ b/TicketV1/Visibility/Task/task-info.yaml
@@ -17,10 +17,10 @@ files:
   - name: tests/tests.rs
     visible: true
     placeholders:
-      - offset: 1152
+      - offset: 1155
         length: 51
         placeholder_text: "assert_eq!(ticket.description, \"A description\");"
-      - offset: 1864
+      - offset: 1863
         length: 169
         placeholder_text: "let ticket = Ticket {  \n\t\t\t title: \"A title\".into(),\n\
       \t\t\t description: \"A description\".into(),\n\t\t\t status: \"To-Do\".into()\

--- a/TicketV2/Enums/Task/task-info.yaml
+++ b/TicketV2/Enums/Task/task-info.yaml
@@ -3,18 +3,21 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
+      - offset: 414
+        length: 6
+        placeholder_text: String
       - offset: 425
         length: 40
         placeholder_text: /* TODO */
       - offset: 488
-        length: 33
+        length: 31
         placeholder_text: /* TODO */
-      - offset: 598
+      - offset: 596
         length: 6
-        placeholder_text: /* TODO */
+        placeholder_text: String
       - offset: 1280
         length: 7
-        placeholder_text: /* TODO */
+        placeholder_text: String
   - name: Cargo.toml
     visible: false
   - name: tests/tests.rs

--- a/TicketV2/ErrorEnums/Task/task-info.yaml
+++ b/TicketV2/ErrorEnums/Task/task-info.yaml
@@ -7,28 +7,28 @@ files:
         length: 16
         placeholder_text: /* TODO */
       - offset: 288
-        length: 48
+        length: 49
         placeholder_text: /* TODO */
       - offset: 701
-        length: 320
+        length: 321
         placeholder_text: /* TODO */
       - offset: 1453
-        length: 107
+        length: 108
         placeholder_text: |-
           /* TODO */
                     return Err("Title cannot be empty".to_string());
       - offset: 1613
-        length: 122
+        length: 123
         placeholder_text: |-
           /* TODO */
                     return Err("Title cannot be longer than 50 bytes".to_string());
       - offset: 1794
-        length: 119
+        length: 120
         placeholder_text: |-
           /* TODO */
                     return Err("Description cannot be empty".to_string());
       - offset: 1973
-        length: 135
+        length: 136
         placeholder_text: |-
           /* TODO */
                     return Err("Description cannot be longer than 500 bytes".to_string());

--- a/TicketV2/ErrorTrait/Task/task-info.yaml
+++ b/TicketV2/ErrorTrait/Task/task-info.yaml
@@ -3,14 +3,14 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 426
-        length: 294
+      - offset: 427
+        length: 295
         placeholder_text: /* TODO */
-      - offset: 722
+      - offset: 724
         length: 44
         placeholder_text: /* TODO */
-      - offset: 1129
-        length: 362
+      - offset: 1131
+        length: 363
         placeholder_text: /* TODO */
   - name: Cargo.toml
     visible: false

--- a/TicketV2/Outro/Task/task-info.yaml
+++ b/TicketV2/Outro/Task/task-info.yaml
@@ -22,8 +22,8 @@ files:
       - offset: 125
         length: 34
         placeholder_text: /* TODO */
-      - offset: 216
-        length: 810
+      - offset: 217
+        length: 811
         placeholder_text: /* TODO */
   - name: src/title.rs
     visible: true
@@ -32,5 +32,5 @@ files:
         length: 34
         placeholder_text: /* TODO */
       - offset: 371
-        length: 818
+        length: 819
         placeholder_text: /* TODO */

--- a/TicketV2/Packages/Task/task-info.yaml
+++ b/TicketV2/Packages/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/main.rs
     visible: true
   - name: Cargo.toml
-    visible: false
+    visible: true
   - name: tests/output.txt
     visible: false
     propagatable: false

--- a/TicketV2/VariantsWithData/Task/task-info.yaml
+++ b/TicketV2/VariantsWithData/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 1012
+      - offset: 1011
         length: 175
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/Traits/DerefTrait/Task/task-info.yaml
+++ b/Traits/DerefTrait/Task/task-info.yaml
@@ -3,10 +3,10 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 694
+      - offset: 693
         length: 17
         placeholder_text: /* TODO */
-      - offset: 767
+      - offset: 766
         length: 23
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/Traits/OperatorOverloading/Task/task-info.yaml
+++ b/Traits/OperatorOverloading/Task/task-info.yaml
@@ -3,7 +3,7 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 394
+      - offset: 393
         length: 172
         placeholder_text: /* TODO */
   - name: Cargo.toml

--- a/Traits/StringSlices/Task/task-info.yaml
+++ b/Traits/StringSlices/Task/task-info.yaml
@@ -3,13 +3,13 @@ files:
   - name: src/lib.rs
     visible: true
     placeholders:
-      - offset: 975
+      - offset: 977
         length: 4
         placeholder_text: /* TODO */
-      - offset: 1042
+      - offset: 1044
         length: 4
         placeholder_text: /* TODO */
-      - offset: 1110
+      - offset: 1112
         length: 4
         placeholder_text: /* TODO */
   - name: Cargo.toml


### PR DESCRIPTION
There were a bunch of exercises where positions of the placeholders were off. This patch fixes them. In some places I also replaced the `/*TODO*/` placeholder with the `todo!()` placeholder for better syntax highlighting.