### PR TITLE
  Fix broken cross-links in course theory files

### DIFF
--- a/ABasicCalculator/ConversionsAsCasting/Theory/task.md
+++ b/ABasicCalculator/ConversionsAsCasting/Theory/task.md
@@ -83,7 +83,7 @@ error: literal out of range for `i8`
 As a rule of thumb, be quite careful with `as` casting.\
 Use it _exclusively_ for going from a smaller type to a larger type.
 To convert from a larger to smaller integer type, rely on the
-[_fallible_ conversion machinery](../../../Ticket%20v2/TryFrom%20trait/Theory/task.md) that we'll
+[_fallible_ conversion machinery](../../../TicketV2/TryFromTrait/Theory/task.md) that we'll
 explore later in the course.
 
 ### Limitations
@@ -92,8 +92,8 @@ Surprising behaviour is not the only downside of `as` casting.
 It is also fairly limited: you can only rely on `as` casting
 for primitive types and a few other special cases.\
 When working with composite types, you'll have to rely on
-different conversion mechanisms ([fallible](../../../Ticket%20v2/TryFrom%20trait/Theory/task.md)
-and [infallible](../../../Traits/From%20trait/Theory/task.md), which we'll explore later on.
+different conversion mechanisms ([fallible](../../../TicketV2/TryFromTrait/Theory/task.md)
+and [infallible](../../../Traits/FromTrait/Theory/task.md), which we'll explore later on.
 
 ## Further reading
 

--- a/ABasicCalculator/Integers/Theory/task.md
+++ b/ABasicCalculator/Integers/Theory/task.md
@@ -112,7 +112,7 @@ error[E0308]: mismatched types
   |
 ```
 
-We'll see how to convert between types [later in this course](../../../Traits/From%20trait/Theory/task.md)
+We'll see how to convert between types [later in this course](../../../Traits/FromTrait/Theory/task.md)
 
 ## Further reading
 
@@ -122,8 +122,8 @@ We'll see how to convert between types [later in this course](../../../Traits/Fr
 
 [^traits]: Rust doesn't let you define custom operators, but it puts you in control of how the built-in operators
 behave.
-We'll talk about operator overloading [later in the course](../../../Traits/Operator%20overloading/Theory/task.md), after we've covered traits.
+We'll talk about operator overloading [later in the course](../../../Traits/OperatorOverloading/Theory/task.md), after we've covered traits.
 
 [^coercion]: There are some exceptions to this rule, mostly related to references, smart pointers and ergonomics. We'll
-cover those [later on](../../../Traits/Deref%20trait/Theory/task.md).
+cover those [later on](../../../Traits/DerefTrait/Theory/task.md).
 A mental model of "all conversions are explicit" will serve you well in the meantime.

--- a/ABasicCalculator/Panics/Theory/task.md
+++ b/ABasicCalculator/Panics/Theory/task.md
@@ -38,7 +38,7 @@ fn main() {
 }
 ```
 
-There are other mechanisms to work with recoverable errors in Rust, which [we'll cover later](../../../Ticket%20v2/Fallibility/Theory/task.md).
+There are other mechanisms to work with recoverable errors in Rust, which [we'll cover later](../../../TicketV2/Fallibility/Theory/task.md).
 For the time being we'll stick with panics as a brutal but simple stopgap solution.
 
 ## Further reading

--- a/TicketV1/Destructors/Theory/task.md
+++ b/TicketV1/Destructors/Theory/task.md
@@ -166,4 +166,4 @@ a close relative of [**use-after-free bugs**](https://owasp.org/www-community/vu
 Rust's ownership system rules out these kinds of bugs by design.
 
 [^leak]: Rust doesn't guarantee that destructors will run. They won't, for example, if
-you explicitly choose to [leak memory](../../../Threads/Leaking%20memory/Theory/task.md).
+you explicitly choose to [leak memory](../../../Threads/LeakingMemory/Theory/task.md).

--- a/TicketV1/Encapsulation/Theory/task.md
+++ b/TicketV1/Encapsulation/Theory/task.md
@@ -56,4 +56,4 @@ Accessor methods are public methods that allow you to read the value of a privat
 Rust doesn't have a built-in way to generate accessor methods for you, like some other languages do.
 You have to write them yourself—they're just regular methods.
 
-[^newtype]: Or refine their type, a technique we'll explore [later on](../../../Ticket%20v2/Outro/Theory/task.md).
+[^newtype]: Or refine their type, a technique we'll explore [later on](../../../TicketV2/Outro/Theory/task.md).

--- a/TicketV1/Ownership/Theory/task.md
+++ b/TicketV1/Ownership/Theory/task.md
@@ -236,4 +236,4 @@ Towards the end of this chapter we'll explain _why_ Rust's ownership system is d
 For the time being, focus on understanding the _how_. Take each compiler error as a learning opportunity!
 
 [^refine]: This is a great mental model to start out, but it doesn't capture the _full_ picture.
-We'll refine our understanding of references [later in the course](../../../Threads/Interior%20mutability/Theory/task.md).
+We'll refine our understanding of references [later in the course](../../../Threads/InteriorMutability/Theory/task.md).

--- a/TicketV1/ReferencesInMemory/Theory/task.md
+++ b/TicketV1/ReferencesInMemory/Theory/task.md
@@ -45,6 +45,6 @@ The same goes for `&mut String`.
 The example above should clarify one thing: not all pointers point to the heap.\
 They just point to a memory location, which _may_ be on the heap, but doesn't have to be.
 
-[^fat]: [Later in the course](../../../Traits/String%20slices/Theory/task.md) we'll talk about **fat pointers**,
+[^fat]: [Later in the course](../../../Traits/StringSlices/Theory/task.md) we'll talk about **fat pointers**,
 i.e. pointers with additional metadata. As the name implies, they are larger than
 the pointers we discussed in this chapter, also known as **thin pointers**.

--- a/TicketV1/Structs/Theory/task.md
+++ b/TicketV1/Structs/Theory/task.md
@@ -98,7 +98,7 @@ let is_open = ticket.is_open();
 ```
 
 This is the same calling syntax you used to perform saturating arithmetic operations on `u32` values
-in [the previous chapter](../02_basic_calculator/09_saturating.md).
+in [the previous chapter](../../../ABasicCalculator/SaturatingArithmetic/Theory/task.md).
 
 ### Static methods
 

--- a/TicketV2/Enums/Theory/task.md
+++ b/TicketV2/Enums/Theory/task.md
@@ -1,6 +1,6 @@
 ## Enumerations
 
-Based on the validation logic you wrote [in a previous section](../../../Ticket%20v1/Validation/Theory/task.md),
+Based on the validation logic you wrote [in a previous section](../../../TicketV1/Validation/Theory/task.md),
 there are only a few valid statuses for a ticket: `To-Do`, `InProgress` and `Done`.\
 This is not obvious if we look at the `status` field in the `Ticket` struct or at the type of the `status`
 parameter in the `new` method:

--- a/TicketV2/ErrorTrait/Theory/task.md
+++ b/TicketV2/ErrorTrait/Theory/task.md
@@ -22,13 +22,13 @@ that implements the `Error` trait.
 pub trait Error: Debug + Display {}
 ```
 
-You might recall the `:` syntax from [the `From` trait](../../../Traits/From%20trait/Theory/task.md#supertrait--subtrait)—it's used to specify **supertraits**.
+You might recall the `:` syntax from [the `From` trait](../../../Traits/FromTrait/Theory/task.md#supertrait--subtrait)—it's used to specify **supertraits**.
 For `Error`, there are two supertraits: `Debug` and `Display`. If a type wants to implement `Error`, it must also
 implement `Debug` and `Display`.
 
 ### `Display` and `Debug`
 
-We've already encountered the `Debug` trait in [a previous lesson](../../../Traits/Derive%20macros/Theory/task.md)—it's the trait used by
+We've already encountered the `Debug` trait in [a previous lesson](../../../Traits/DeriveMacros/Theory/task.md)—it's the trait used by
 `assert_eq!` to display the values of the variables it's comparing when the assertion fails.
 
 From a "mechanical" perspective, `Display` and `Debug` are identical—they encode how a type should be converted

--- a/TicketV2/TryFromTrait/Theory/task.md
+++ b/TicketV2/TryFromTrait/Theory/task.md
@@ -1,6 +1,6 @@
 ## `TryFrom` and `TryInto`
 
-In the previous chapter we looked at the [`From` and `Into` traits](../../../Traits/From%20trait/Theory/task.md),
+In the previous chapter we looked at the [`From` and `Into` traits](../../../Traits/FromTrait/Theory/task.md),
 Rust's idiomatic interfaces for **infallible** type conversions.\
 But what if the conversion is not guaranteed to succeed?
 

--- a/Traits/DropTrait/Theory/task.md
+++ b/Traits/DropTrait/Theory/task.md
@@ -1,6 +1,6 @@
 ## The `Drop` trait
 
-When we introduced [destructors](../../../Ticket%20v1/Destructors/Theory/task.md),
+When we introduced [destructors](../../../TicketV1/Destructors/Theory/task.md),
 we mentioned that the `drop` function:
 
 1. reclaims the memory occupied by the type (i.e. `std::mem::size_of` bytes)

--- a/Traits/SizedTrait/Theory/task.md
+++ b/Traits/SizedTrait/Theory/task.md
@@ -2,11 +2,11 @@
 
 There's more to `&str` than meets the eye, even after having
 investigated deref coercion.\
-From our previous [discussion on memory layouts](../../../Ticket%20v1/References%20in%20memory/Theory/task.md),
+From our previous [discussion on memory layouts](../../../TicketV1/ReferencesInMemory/Theory/task.md),
 it would have been reasonable to expect `&str` to be represented as a single `usize` on
 the stack, a pointer. That's not the case though. `&str` stores some **metadata** next
 to the pointer: the length of the slice it points to. Going back to the example from
-[a previous section](../../String%20slices/Theory/task.md):
+[a previous section](../../StringSlices/Theory/task.md):
 
 ```rust
 let mut s = String::with_capacity(5);

--- a/Traits/StringSlices/Theory/task.md
+++ b/Traits/StringSlices/Theory/task.md
@@ -18,7 +18,7 @@ The type of `s` is `&str`, a **reference to a string slice**.
 
 `&str` and `String` are different types—they're not interchangeable.\
 Let's recall the memory layout of a `String` from our
-[previous exploration](../../../Ticket%20v1/Heap/Theory/task.md).
+[previous exploration](../../../TicketV1/Heap/Theory/task.md).
 If we run:
 
 ```rust
@@ -41,7 +41,7 @@ Heap:  | H | e | l | l | o |
        +---+---+---+---+---+
 ```
 
-If you remember, we've [also examined](../../../Ticket%20v1/References%20in%20memory/Theory/task.md)
+If you remember, we've [also examined](../../../TicketV1/ReferencesInMemory/Theory/task.md)
 how a `&String` is laid out in memory:
 
 ```text

--- a/Traits/TraitBounds/Theory/task.md
+++ b/Traits/TraitBounds/Theory/task.md
@@ -170,7 +170,7 @@ Follow Rust's conventions, though: use [upper camel case for type parameter name
 
 You may wonder why we need trait bounds at all. Can't the compiler infer the required traits from the function's body?\
 It could, but it won't.\
-The rationale is the same as for [explicit type annotations on function parameters](../../../A%20Basic%20Calculator/Variables/Theory/task.md#function-arguments-are-variables):
+The rationale is the same as for [explicit type annotations on function parameters](../../../ABasicCalculator/Variables/Theory/task.md#function-arguments-are-variables):
 each function signature is a contract between the caller and the callee, and the terms must be explicitly stated.
 This allows for better error messages, better documentation, less unintentional breakages across versions,
 and faster compilation times.


### PR DESCRIPTION
# Problem

  Many theory sections link to other lessons using relative markdown links. These links were written against an older directory layout that used human-readable, space-separated folder names (e.g. Ticket v2, TryFrom trait, A Basic Calculator), with spaces URL-encoded as %20:

```
  [we'll cover later](../../../Ticket%20v2/Fallibility/Theory/task.md)
```

  The directories have since been renamed to CamelCase without spaces (TicketV2, TryFromTrait, ABasicCalculator), but the links were never updated. As a result the paths no longer resolve — the link above points to Ticket v2/…, which doesn't exist; the real path is TicketV2/…. One link also used a stale numbered path from the original mdbook source (../02_basic_calculator/09_saturating.md).

  A scan of all 196 markdown files found 22 broken cross-links (out of 39 relative links total), spread across 15 theory files.

# Fix

  Repointed every broken link to its correct current path. Fixes were generated by resolving each link component against the actual filesystem (normalizing away spaces/casing), so all corrected targets are verified to exist. Two links carried heading anchors (#supertrait--subtrait, #function-arguments-are-variables) which were preserved, and the stale numbered path was mapped to ABasicCalculator/SaturatingArithmetic/Theory/task.md.

  Verification
  
  - Before: 22 / 39 relative cross-links broken
  - After: 0 broken links

  No content was changed other than the link targets.