### PR TITLE
Update placeholders for the changed Cargo.toml files

### DIFF
--- a/TicketV2/Dependencies/Task/task-info.yaml
+++ b/TicketV2/Dependencies/Task/task-info.yaml
@@ -4,7 +4,7 @@ files:
     visible: true
     placeholders:
       - offset: 73
-        length: 32
+        length: 27
         placeholder_text: "# TODO"
   - name: tests/output.txt
     visible: false

--- a/TicketV2/thiserror/Task/task-info.yaml
+++ b/TicketV2/thiserror/Task/task-info.yaml
@@ -22,7 +22,7 @@ files:
     visible: true
     placeholders:
       - offset: 151
-        length: 20
+        length: 15
         placeholder_text: "# TODO"
   - name: tests/tests.rs
     visible: true


### PR DESCRIPTION
Updating dependencies to shorter versions in #21 caused the placeholder area, that covered them, to shrink. The out-of-date placeholder lengths caused build failure. Now it is fixed.