### PR TITLE
Fix links within same section

### DIFF
--- a/ABasicCalculator/OverflowAndUnderflow/Theory/task.md
+++ b/ABasicCalculator/OverflowAndUnderflow/Theory/task.md
@@ -16,7 +16,7 @@ But the _mathematically correct result_ doesn't fit into that integer type!
 > For brevity, we'll only talk about integer overflows for the rest of this section, but keep in mind that
 > everything we say applies to integer underflows as well.
 >
-> The `speed` function you wrote in the ["Variables" lesson](../../Variables/Theory/task.md) underflowed for some input
+> The `speed` function you wrote in the ["Variables" lesson](../../../ABasicCalculator/Variables/Theory/task.md) underflowed for some input
 > combinations.
 > E.g. if `end` is smaller than `start`, `end - start` will underflow the `u32` type since the result is supposed
 > to be negative but `u32` can't represent negative numbers.
@@ -41,7 +41,7 @@ It boils down to two different approaches:
 ### Reject the operation
 
 This is the most conservative approach: we stop the program when an integer overflow occurs.\
-That's done via a panic, the mechanism we've already seen in the ["Panics" lesson](../../Panics/Theory/task.md).
+That's done via a panic, the mechanism we've already seen in the ["Panics" lesson](../../../ABasicCalculator/Panics/Theory/task.md).
 
 ### Come up with a "sensible" result
 

--- a/ABasicCalculator/Panics/Theory/task.md
+++ b/ABasicCalculator/Panics/Theory/task.md
@@ -1,6 +1,6 @@
 ## Panics
 
-Let's go back to the `speed` function you wrote for the ["Variables" lesson](../../Variables/Theory/task.md).
+Let's go back to the `speed` function you wrote for the ["Variables" lesson](../../../ABasicCalculator/Variables/Theory/task.md).
 It probably looked something like this:
 
 ```rust

--- a/TicketV1/Encapsulation/Theory/task.md
+++ b/TicketV1/Encapsulation/Theory/task.md
@@ -38,7 +38,7 @@ let ticket = Ticket {
 You've seen this in action in the previous exercise on visibility.\
 We now need to provide one or more public **constructors**—i.e. static methods or functions that can be used
 from outside the module to create a new instance of the struct.\
-Luckily enough we already have one: `Ticket::new`, as implemented in [a Validation lesson](../../Validation/Theory/task.md).
+Luckily enough we already have one: `Ticket::new`, as implemented in [a Validation lesson](../../../TicketV1/Validation/Theory/task.md).
 
 ## Accessor methods
 

--- a/Traits/SizedTrait/Theory/task.md
+++ b/Traits/SizedTrait/Theory/task.md
@@ -6,7 +6,7 @@ From our previous [discussion on memory layouts](../../../TicketV1/ReferencesInM
 it would have been reasonable to expect `&str` to be represented as a single `usize` on
 the stack, a pointer. That's not the case though. `&str` stores some **metadata** next
 to the pointer: the length of the slice it points to. Going back to the example from
-[a previous section](../../StringSlices/Theory/task.md):
+[a previous section](../../../Traits/StringSlices/Theory/task.md):
 
 ```rust
 let mut s = String::with_capacity(5);


### PR DESCRIPTION
# Problem

Five in-course links used section-relative paths (two `../` levels), e.g. `[…](../../Variables/Theory/task.md)`. These resolve correctly in the RustRover course preview, which resolves links relative to the task's own folder — so they were never caught before. But the built course resolves in-course links relative to the course root (with .. clamped at the root), which collapses `../../Variables/Theory/task.md` to `Variables/Theory/task.md` — a lesson that doesn't exist at the top level, because the `ABasicCalculator/` section prefix is missing. The links were therefore dead in the built course.

This is why the earlier "Fix broken internal links" PR (#23) didn't catch them: that PR only un-encoded `%20` folder names in cross-section links, and these five had no `%20`. Cross-section links already worked in both environments because they're written as full, section-qualified paths from the root (`../../../SECTION/LESSON/Theory/task.md`).

# Fix

Rewrote all five as section-qualified, root-relative paths (three `../` + section name), matching the convention already used by every working cross-section link.